### PR TITLE
 SHOR-5: Add screens for civicase extensions to backstopjs

### DIFF
--- a/tests/backstop_data/backstop.tpl.json
+++ b/tests/backstop_data/backstop.tpl.json
@@ -14,7 +14,81 @@
     "html_report": "html_report",
     "ci_report": "ci_report"
   },
-  "scenarios": [],
+  "scenarios": [
+    {
+      "label": "Civicase - Dashboard",
+      "url": "{url}/civicrm/case?reset=1",
+      "onReadyScript": "civicase/dashboard.js"
+    },
+    {
+      "label": "Civicase - Find Cases - Search",
+      "url": "{url}/civicrm/case/search?reset=1"
+    },
+    {
+      "label": "Civicase - Find My Cases",
+      "url": "{url}/civicrm/case?reset=1",
+      "onReadyScript": "civicase/find.js"
+    },
+    {
+      "label": "Civicase - Add Case",
+      "url": "{url}/civicrm/case/add?action=add&context=standalone&reset=1",
+      "onReadyScript": "common/wait-for-wysiwyg.js"
+    },
+    {
+      "label": "Civicase - Manage Case",
+      "url": "{url}/civicrm/case?reset=1",
+      "onReadyScript": "civicase/manage.js"
+    },
+    {
+      "label": "Civicase - Delete Case",
+      "url": "{url}/civicrm/case?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "civicase/delete.js"
+    },
+    {
+      "label": "Civicase - Assign to others case",
+      "url": "{url}/civicrm/case?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "civicase/assign-to-others.js"
+    },
+    {
+      "label": "Civicase - View case activity",
+      "url": "{url}/civicrm/case?reset=1",
+      "onReadyScript": "civicase/case-activity.js"
+    },
+    {
+      "label": "Civicase - Case Report",
+      "url": "{url}/civicrm/report/list?compid=7&reset=1"
+    },
+    {
+      "label": "Civicase - New Case Report",
+      "url": "{url}/civicrm/report/template/list?reset=1&compid=7"
+    },
+    {
+      "label": "Civicase - Case Summary Report - Columns",
+      "url": "{url}/civicrm/report/case/summary"
+    },
+    {
+      "label": "Civicase - Case Summary Report - Sorting",
+      "url": "{url}/civicrm/report/case/summary",
+      "onReadyScript": "civicase/summary-report-sorting.js"
+    },
+    {
+      "label": "Civicase - Case Summary Report - Filters",
+      "url": "{url}/civicrm/report/case/summary",
+      "onReadyScript": "civicase/summary-report-filters.js"
+    },
+    {
+      "label": "Civicase - Case Time Spent Report - Grouping",
+      "url": "{url}/civicrm/report/case/timespent",
+      "onReadyScript": "civicase/timespent-report-grouping.js"
+    },
+    {
+      "label": "Civicase - Case Detail Report - Display Options",
+      "url": "{url}/civicrm/report/case/detail",
+      "onReadyScript": "civicase/detail-report-display-options.js"
+    }
+  ],
   "report": ["CLI", "browser"],
   "engine": "puppeteer",
   "engineOptions": {

--- a/tests/backstop_data/backstop.tpl.json
+++ b/tests/backstop_data/backstop.tpl.json
@@ -32,7 +32,7 @@
     {
       "label": "Civicase - Add Case",
       "url": "{url}/civicrm/case/add?action=add&context=standalone&reset=1",
-      "onReadyScript": "common/wait-for-wysiwyg.js"
+      "onReadyScript": "civicase/add.js"
     },
     {
       "label": "Civicase - Manage Case",

--- a/tests/backstop_data/engine_scripts/puppet/civicase/add.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/add.js
@@ -1,19 +1,5 @@
 'use strict';
 
 module.exports = async (engine, scenario, vp) => {
-  const isWysiwygVisible = await engine.evaluate((selector) => {
-    const e = document.querySelector(selector);
-
-    if (!e) {
-      return false;
-    }
-
-    const style = window.getComputedStyle(e);
-
-    return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0' && e.offsetHeight > 0;
-  }, '.crm-form-wysiwyg');
-
-  if (isWysiwygVisible) {
-    await engine.waitFor('.cke .cke_contents', { visible: true });
-  }
+   await engine.waitFor('.cke .cke_contents', { visible: true })
 };

--- a/tests/backstop_data/engine_scripts/puppet/civicase/add.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/add.js
@@ -1,0 +1,19 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  const isWysiwygVisible = await engine.evaluate((selector) => {
+    const e = document.querySelector(selector);
+
+    if (!e) {
+      return false;
+    }
+
+    const style = window.getComputedStyle(e);
+
+    return style && style.display !== 'none' && style.visibility !== 'hidden' && style.opacity !== '0' && e.offsetHeight > 0;
+  }, '.crm-form-wysiwyg');
+
+  if (isWysiwygVisible) {
+    await engine.waitFor('.cke .cke_contents', { visible: true });
+  }
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/assign-to-others.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/assign-to-others.js
@@ -3,6 +3,8 @@
 module.exports = async (engine, scenario, vp) => {
   await require('./find.js')(engine, scenario, vp);
   await engine.click('a[title="Assign to Another Client"]');
-  await engine.waitFor('.modal-dialog > form');
-  await engine.waitFor(500);
+  await engine.waitForSelector('.modal-dialog > form', { visible: true });
+  await engine.waitForSelector('.blockUI.blockOverlay', { hidden: true });
+  //wait for modal adjustment
+  await engine.waitFor(200);
 };

--- a/tests/backstop_data/engine_scripts/puppet/civicase/assign-to-others.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/assign-to-others.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find.js')(engine, scenario, vp);
+  await engine.click('a[title="Assign to Another Client"]');
+  await engine.waitFor('.modal-dialog > form');
+  await engine.waitFor(500);
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/case-activity.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/case-activity.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./dashboard.js')(engine, scenario, vp);
+  await engine.click('a[title="Activities"]');
+  await engine.waitFor('.crm-child-row', {visible: true});
+  await engine.waitFor('.blockUI.blockOverlay', { hidden: true });
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/case-activity.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/case-activity.js
@@ -3,6 +3,6 @@
 module.exports = async (engine, scenario, vp) => {
   await require('./dashboard.js')(engine, scenario, vp);
   await engine.click('a[title="Activities"]');
-  await engine.waitFor('.crm-child-row', {visible: true});
+  await engine.waitFor('.crm-child-row', { visible: true });
   await engine.waitFor('.blockUI.blockOverlay', { hidden: true });
 };

--- a/tests/backstop_data/engine_scripts/puppet/civicase/dashboard.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/dashboard.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.waitForSelector('.dataTables_wrapper .crm-entity', { visible: true });
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/dashboard.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/dashboard.js
@@ -1,5 +1,9 @@
 'use strict';
 
 module.exports = async (engine, scenario, vp) => {
-  await engine.waitForSelector('.dataTables_wrapper .crm-entity', { visible: true });
+  await engine.waitFor(() => {
+    const tables = document.querySelectorAll('.dataTables_processing');
+
+    return tables.length > 0 && Array.from(tables).every(table => table.style.display === 'none');
+  });
 };

--- a/tests/backstop_data/engine_scripts/puppet/civicase/delete.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/delete.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find.js')(engine, scenario, vp);
+  await engine.click('a[title="Delete Case"]');
+  await engine.waitFor('.modal-dialog > form', { visible: true });
+  await engine.waitFor('.blockUI.blockOverlay', { hidden: true });
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/detail-report-display-options.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/detail-report-display-options.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.click('a[title="Display Options"]');
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/find.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/find.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await Promise.all([
+    engine.click('a[name="find_my_cases"]'),
+    engine.waitForNavigation()
+  ]);
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/manage.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/manage.js
@@ -2,21 +2,27 @@
 
 module.exports = async (engine, scenario, vp) => {
   await require('./find.js')(engine, scenario, vp);
-  await Promise.all([
-    engine.click('a[title="Manage Case"]'),
-    engine.waitForNavigation()
-  ]);
+  await engine.goto(await buildUrl.call(this, engine, 'a[title="Manage Case"]'), {'waitUntil': 'networkidle0'});
+  // open all accordions
   await engine.evaluate(selector => {
     document.querySelectorAll(selector).forEach(element => element.click());
   }, 'div.crm-accordion-wrapper.collapsed > div');
-  try {
-    await this.engine.waitFor('.blockUI.blockOverlay', { hidden: true });
-    await this.engine.waitFor('.loading-text', { hidden: true, timeout: 8000 });
-    await this.engine.waitFor('[alt="loading"]', { hidden: true });
-    // wait for reedjustment of the modal after ajax content load after opening accordion
-    await this.engine.waitFor(500);
-    console.log('All accordion blocks loaded');
-  } catch (e) {
-    console.log('Loaders still visible and timeout reached!');
-  }  
 };
+
+/**
+  * Builds full absolute url for the new page to be navigated to
+  *
+  * @param {Object} engine - engine object of puppeter
+  * @param {String} selector - <a> tag selector to be clicked on for navigation
+  *
+  * @return {String} - Full absolute url for Manage cases page
+  */
+async function buildUrl (engine, selector) {
+  const urlRegex = /^(.*:)\/\/([A-Za-z0-9\-.]+)(:[0-9]+)?(.*)$/g;
+  const urlElements = urlRegex.exec(engine.url());
+  const relativeUrl = await engine.evaluate((selector) => {
+    return document.querySelector(selector).getAttribute('href');
+  }, selector);
+
+  return urlElements[1] + '//' + urlElements[2] + (urlElements[3] !== undefined ? urlElements[3] : '') + relativeUrl;
+}

--- a/tests/backstop_data/engine_scripts/puppet/civicase/manage.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/manage.js
@@ -1,0 +1,22 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find.js')(engine, scenario, vp);
+  await Promise.all([
+    engine.click('a[title="Manage Case"]'),
+    engine.waitForNavigation()
+  ]);
+  await engine.evaluate(selector => {
+    document.querySelectorAll(selector).forEach(element => element.click());
+  }, 'div.crm-accordion-wrapper.collapsed > div');
+  try {
+    await this.engine.waitFor('.blockUI.blockOverlay', { hidden: true });
+    await this.engine.waitFor('.loading-text', { hidden: true, timeout: 8000 });
+    await this.engine.waitFor('[alt="loading"]', { hidden: true });
+    // wait for reedjustment of the modal after ajax content load after opening accordion
+    await this.engine.waitFor(500);
+    console.log('All accordion blocks loaded');
+  } catch (e) {
+    console.log('Loaders still visible and timeout reached!');
+  }  
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/manage.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/manage.js
@@ -2,27 +2,17 @@
 
 module.exports = async (engine, scenario, vp) => {
   await require('./find.js')(engine, scenario, vp);
-  await engine.goto(await buildUrl.call(this, engine, 'a[title="Manage Case"]'), {'waitUntil': 'networkidle0'});
+  await Promise.all([
+    engine.click('a[title="Manage Case"]'),
+    engine.waitForNavigation()
+  ]);
   // open all accordions
   await engine.evaluate(selector => {
     document.querySelectorAll(selector).forEach(element => element.click());
   }, 'div.crm-accordion-wrapper.collapsed > div');
+  await engine.waitFor(() => {
+    const tables = document.querySelectorAll('.dataTables_processing');
+
+    return tables.length > 0 && Array.from(tables).every(table => table.style.display === 'none');
+  });
 };
-
-/**
-  * Builds full absolute url for the new page to be navigated to
-  *
-  * @param {Object} engine - engine object of puppeter
-  * @param {String} selector - <a> tag selector to be clicked on for navigation
-  *
-  * @return {String} - Full absolute url for Manage cases page
-  */
-async function buildUrl (engine, selector) {
-  const urlRegex = /^(.*:)\/\/([A-Za-z0-9\-.]+)(:[0-9]+)?(.*)$/g;
-  const urlElements = urlRegex.exec(engine.url());
-  const relativeUrl = await engine.evaluate((selector) => {
-    return document.querySelector(selector).getAttribute('href');
-  }, selector);
-
-  return urlElements[1] + '//' + urlElements[2] + (urlElements[3] !== undefined ? urlElements[3] : '') + relativeUrl;
-}

--- a/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-access.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-access.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.click('a[title="Access"]');
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-email-delivery.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-email-delivery.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.click('a[title="Email Delivery"]');
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-filters.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-filters.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.click('a[title="Filters"]');
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-sorting.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-sorting.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.click('a[title="Sorting"]');
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-title-format.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/summary-report-title-format.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.click('a[title="Title and Format"]');
+};

--- a/tests/backstop_data/engine_scripts/puppet/civicase/timespent-report-grouping.js
+++ b/tests/backstop_data/engine_scripts/puppet/civicase/timespent-report-grouping.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.click('a[title="Grouping"]');
+};


### PR DESCRIPTION
## Overview
PR contains screens for 
* Civicase - dashboard
* Civicase - Add new Case 
* Civicase - Search Case
* Civicase - Mange Case 
* Civicase - Delete case
* Civicase - Transfer case
* Civicase - Show reports
* Civicase - view case activity
* Civicase - Show reports - Add new report
* Civicase - Show reports - View all reports
* Civicase - Add new report - Case Summary Report - Columns 
* Civicase - Add new report - Case Summary Report - Sorting
* Civicase - Add new report - Case Summary Report - filters
* Civicase - Add new report - Case Time Spent Report - Grouping
* Civicase - Add new report - Case Detail Report - Display Options

### Screens 
![backstop_civicase_civicase_-_add_case_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616072-82fefd00-85ca-11e8-9864-94e3fd567585.png)
![backstop_civicase_civicase_-_assign_to_others_case_0_ui-dialog_0_desktop](https://user-images.githubusercontent.com/3340537/42616073-833549be-85ca-11e8-80fd-f7c985f31a9e.png)
![backstop_civicase_civicase_-_case_detail_report_-_display_options_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616074-83781c58-85ca-11e8-99f3-15ef54d469f8.png)
![backstop_civicase_civicase_-_case_report_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616076-83a933ec-85ca-11e8-9f0f-73c6199a2a32.png)
![backstop_civicase_civicase_-_case_summary_report_-_columns_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616077-83dbaf98-85ca-11e8-9709-9e41eccaddcd.png)
![backstop_civicase_civicase_-_case_summary_report_-_filters_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616078-8418deea-85ca-11e8-8f66-9df2df346c11.png)
![backstop_civicase_civicase_-_case_summary_report_-_sorting_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616079-845344a4-85ca-11e8-82d4-5180e0137776.png)
![backstop_civicase_civicase_-_case_time_spent_report_-_grouping_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616081-84b1dfdc-85ca-11e8-8a2f-e1d317f41853.png)
![backstop_civicase_civicase_-_dashboard_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616082-84e192a4-85ca-11e8-98f7-0710424826ee.png)
![backstop_civicase_civicase_-_delete_case_0_ui-dialog_0_desktop](https://user-images.githubusercontent.com/3340537/42616083-8514a40a-85ca-11e8-8545-2dadac33f231.png)
![backstop_civicase_civicase_-_find_cases_-_search_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616084-85471386-85ca-11e8-8ba1-338e50f304ef.png)
![backstop_civicase_civicase_-_find_my_cases_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616086-858b4c40-85ca-11e8-9a67-39ffc643bcc7.png)
![backstop_civicase_civicase_-_manage_case_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616087-85ba9446-85ca-11e8-83a0-8577320c6edc.png)
![backstop_civicase_civicase_-_new_case_report_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616088-85e9dbc0-85ca-11e8-8afd-4ccfd39de3cc.png)
![backstop_civicase_civicase_-_view_case_activity_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/42616090-861e7c90-85ca-11e8-8fce-f43fa8a70781.png)

## Technical Details

#### Problem
For Manage personal cases page the page loads many content tables through ajax and wait for the overloy screen to be hidden logic was not working seemless.

#### Fix
 To fix this we used `page.goto` with  `waitUntill` options. Now the real challenge is to create the full absolute url of the page and to do this we created a private function `buildUrl` which uses regex and creates a perfect absolute url to the page. Please see comments on the function for more info